### PR TITLE
Expose the Dialer instance

### DIFF
--- a/pop3.go
+++ b/pop3.go
@@ -18,7 +18,7 @@ import (
 // Client implements a Client e-mail client.
 type Client struct {
 	opt    Opt
-	dialer *net.Dialer
+	dialer Dialer
 }
 
 // Conn is a stateful connection with the POP3 server/
@@ -35,10 +35,14 @@ type Opt struct {
 
 	// Default is 3 seconds.
 	DialTimeout time.Duration `json:"dial_timeout"`
-	Dialer      *net.Dialer   `json:"-"`
+	Dialer      Dialer        `json:"-"`
 
 	TLSEnabled    bool `json:"tls_enabled"`
 	TLSSkipVerify bool `json:"tls_skip_verify"`
+}
+
+type Dialer interface {
+	Dial(network, address string) (net.Conn, error)
 }
 
 // MessageID contains the ID and size of an individual message.


### PR DESCRIPTION
I applied a change that exposes the `net.Dialer` to be used for the connection via the `Opts` struct. Instead of using `net.DialTimeout`, the users of the library can provide a custom `Dialer` to control more aspects of the connection step than just the timeout.
- Passing a simple `Dialer` interface here allows one to mock the actual connection part; making unit tests easier.
- The users can implement custom dialers to extend the behavior, for example a "proxy dialer" can allow the library to direct the traffic through proxies (this is my use case, and the reason why I'm opening this PR)
