### PR TITLE
feat add connection close func

### DIFF
--- a/pop3.go
+++ b/pop3.go
@@ -419,15 +419,10 @@ func (c *Conn) Noop() error {
 // Message deletions (DELE command) are only excuted by the server on a graceful
 // quit and close.
 func (c *Conn) Quit() error {
+	defer c.conn.Close()
 	if _, err := c.Cmd("QUIT", false); err != nil {
 		return err
 	}
-	return c.conn.Close()
-}
-
-// Close close the underlying tcp connection
-func (c *Conn) Close() error {
-	return c.conn.Close()
 }
 
 // parseResp checks if the response is an error that starts with `-ERR`

--- a/pop3.go
+++ b/pop3.go
@@ -425,6 +425,11 @@ func (c *Conn) Quit() error {
 	return c.conn.Close()
 }
 
+// Close close the underlying tcp connection
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
 // parseResp checks if the response is an error that starts with `-ERR`
 // and returns an error with the message that succeeds the error indicator.
 // For success `+OK` messages, it returns the remaining response bytes.


### PR DESCRIPTION
`c.Quit` will not always close tcp conn,because of the failure of the **QUIT** cmd
and it causes leak of  tcp conn

maybe we should change README example too